### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ EXT := a
 endif
 
 # Linux/BSDs
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
    EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).
